### PR TITLE
SAVS-20: Gestionnaire de ticket

### DIFF
--- a/app/Livewire/Admin/Support/Bug/BugList.php
+++ b/app/Livewire/Admin/Support/Bug/BugList.php
@@ -2,12 +2,63 @@
 
 namespace App\Livewire\Admin\Support\Bug;
 
+use Jira\Laravel\Facades\Jira;
+use Livewire\Attributes\Title;
 use Livewire\Component;
 
 class BugList extends Component
 {
+    public $search = '';
+    public $statusFilter = '';
+    public $priorityFilter = '';
+    public $composantFilter = '';
+
+    private $searchRender = '';
+    private $statusRender = '';
+    private $priorityRender = '';
+    private $composantRender = '';
+    #[Title("Gestionnaire de Bugs - Powered by Jira Software")]
     public function render()
     {
-        return view('livewire.admin.support.bug.bug-list');
+        if($this->search != '') {
+            $this->searchRender = str_replace($this->search, 'AND summary ~ '.$this->search, $this->search);
+        } else {
+            $this->searchRender = '';
+        }
+
+        if($this->priorityFilter != '') {
+            $this->priorityRender = str_replace($this->priorityFilter, 'AND priority = '.$this->priorityFilter, $this->priorityFilter);
+        } else {
+            $this->priorityRender = '';
+        }
+
+        if($this->statusFilter != '') {
+            $this->statusRender = str_replace($this->statusFilter, 'AND status = '.$this->statusFilter, $this->statusFilter);
+        } else {
+            $this->statusRender = '';
+        }
+
+        if($this->composantFilter != '') {
+            $this->composantRender = str_replace($this->composantFilter, 'AND component = '.$this->composantFilter, $this->composantFilter);
+        } else {
+            $this->composantRender = '';
+        }
+
+        return view('livewire.admin.support.bug.bug-list', [
+            "bugs" => Jira::issues()->search([
+                "jql" => "project = 'Vortech Studio Helpdesk' {$this->searchRender} {$this->priorityFilter} AND issuetype = Bug {$this->statusRender} {$this->composantRender} ORDER BY created DESC",
+            ])['issues']
+        ])
+            ->layout("components.layouts.admin");
+    }
+
+    public function refreshFilter()
+    {
+        $this->statusFilter = '';
+        $this->priorityFilter = '';
+        $this->search = '';
+        $this->priorityRender = '';
+        $this->statusRender = '';
+        $this->searchRender = '';
     }
 }

--- a/app/Livewire/Admin/Support/Ticket/TicketChat.php
+++ b/app/Livewire/Admin/Support/Ticket/TicketChat.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Livewire\Admin\Support\Ticket;
+
+use App\Models\Support\Ticket\Ticket;
+use Livewire\Component;
+
+class TicketChat extends Component
+{
+    public Ticket $ticket;
+    public function render()
+    {
+        return view('livewire.admin.support.ticket.ticket-chat', [
+            "ticket" => $this->ticket,
+            "responses" => $this->ticket->responses()->orderBy('created_at', 'desc')->get()
+        ]);
+    }
+}

--- a/app/Livewire/Admin/Support/Ticket/TicketList.php
+++ b/app/Livewire/Admin/Support/Ticket/TicketList.php
@@ -2,12 +2,65 @@
 
 namespace App\Livewire\Admin\Support\Ticket;
 
+use App\Models\Support\Ticket\Ticket;
+use Jantinnerezo\LivewireAlert\LivewireAlert;
+use Livewire\Attributes\Title;
 use Livewire\Component;
+use Livewire\WithPagination;
 
 class TicketList extends Component
 {
+    use WithPagination, LivewireAlert;
+    public $search = '';
+    public $perPage = 10;
+    public $priorityFilter = '';
+    public $statusFilter = '';
+    public $serviceFilter = '';
+    public $sortBy = 'title';
+    public $sortDirection = 'asc';
+    #[Title("Gestionnaire de tickets de support")]
     public function render()
     {
-        return view('livewire.admin.support.ticket.ticket-list');
+        $query = Ticket::with(['user', 'service', 'category'])
+            ->where('title', 'like', '%' . $this->search . '%');
+
+        if($this->priorityFilter) {
+            dd($this->priorityFilter);
+            $query->where('priority', $this->priorityFilter);
+        }
+
+        if($this->statusFilter) {
+            $query->where('status', $this->statusFilter);
+        }
+
+        if($this->serviceFilter) {
+            $query->whereHas('service', function($query) {
+                $query->where('name', $this->serviceFilter);
+            });
+        }
+
+        $tickets = $query->orderBy($this->sortBy, $this->sortDirection)
+            ->paginate($this->perPage);
+
+        return view('livewire.admin.support.ticket.ticket-list', compact('tickets'))
+            ->layout('components.layouts.admin');
     }
+
+    public function updatingSearch()
+    {
+        $this->resetPage();
+    }
+
+
+    public function setOrderField(string $field)
+    {
+        if($this->sortBy === $field) {
+            $this->sortDirection = $this->sortDirection === 'asc' ? 'desc' : 'asc';
+        } else {
+            $this->sortDirection = 'asc';
+        }
+        $this->sortBy = $field;
+    }
+
+
 }

--- a/app/Livewire/Admin/Support/Ticket/TicketList.php
+++ b/app/Livewire/Admin/Support/Ticket/TicketList.php
@@ -2,7 +2,9 @@
 
 namespace App\Livewire\Admin\Support\Ticket;
 
+use App\Livewire\Forms\Admin\Support\Ticket\TicketForm;
 use App\Models\Support\Ticket\Ticket;
+use App\Models\Support\Ticket\TicketCategory;
 use Jantinnerezo\LivewireAlert\LivewireAlert;
 use Livewire\Attributes\Title;
 use Livewire\Component;
@@ -11,6 +13,7 @@ use Livewire\WithPagination;
 class TicketList extends Component
 {
     use WithPagination, LivewireAlert;
+    public TicketForm $form;
     public $search = '';
     public $perPage = 10;
     public $priorityFilter = '';
@@ -18,6 +21,14 @@ class TicketList extends Component
     public $serviceFilter = '';
     public $sortBy = 'title';
     public $sortDirection = 'asc';
+    public $createForm = false;
+
+    public function mount(?int $id = null)
+    {
+        if($id) {
+            $this->form->setTicket(Ticket::find($id));
+        }
+    }
     #[Title("Gestionnaire de tickets de support")]
     public function render()
     {
@@ -25,7 +36,6 @@ class TicketList extends Component
             ->where('title', 'like', '%' . $this->search . '%');
 
         if($this->priorityFilter) {
-            dd($this->priorityFilter);
             $query->where('priority', $this->priorityFilter);
         }
 
@@ -39,6 +49,10 @@ class TicketList extends Component
             });
         }
 
+        if($this->form->selectedService) {
+            $this->form->ticketCategories = TicketCategory::where('service_id', $this->form->selectedService)->get();
+        }
+
         $tickets = $query->orderBy($this->sortBy, $this->sortDirection)
             ->paginate($this->perPage);
 
@@ -46,11 +60,18 @@ class TicketList extends Component
             ->layout('components.layouts.admin');
     }
 
+    public function refreshFilter()
+    {
+        $this->priorityFilter = '';
+        $this->statusFilter = '';
+        $this->serviceFilter = '';
+        $this->search = '';
+    }
+
     public function updatingSearch()
     {
         $this->resetPage();
     }
-
 
     public function setOrderField(string $field)
     {
@@ -60,6 +81,27 @@ class TicketList extends Component
             $this->sortDirection = 'asc';
         }
         $this->sortBy = $field;
+    }
+
+    public function showCreateForm()
+    {
+        $this->createForm = true;
+    }
+    public function hideCreateForm()
+    {
+        $this->createForm = false;
+    }
+
+    public function createTicket()
+    {
+        try {
+            $this->form->save();
+            $this->alert("success", "Le ticket a été créé avec succès");
+            $this->resetPage();
+        } catch (\Exception $e) {
+            \Log::emergency($e->getMessage(), [$e->getCode()]);
+            $this->alert("error", "Une erreur est survenue lors de la création du ticket");
+        }
     }
 
 

--- a/app/Livewire/Admin/Support/Ticket/TicketShow.php
+++ b/app/Livewire/Admin/Support/Ticket/TicketShow.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Livewire\Admin\Support\Ticket;
+
+use App\Models\Support\Ticket\Ticket;
+use App\Models\Support\Ticket\TicketResponse;
+use Jantinnerezo\LivewireAlert\LivewireAlert;
+use Jira\Laravel\Facades\Jira;
+use Livewire\Attributes\Title;
+use Livewire\Component;
+
+class TicketShow extends Component
+{
+    use LivewireAlert;
+    public $ticketId;
+    public $ticket;
+    public $ticketLogs;
+    public $ticketResponses;
+    public $message = '';
+
+    public function mount(int $id)
+    {
+        $this->ticketId = $id;
+        $this->ticket = Ticket::find($id);
+        $this->ticketLogs = $this->ticket->logs()->orderBy('created_at', 'desc')->get();
+        $this->ticketResponses = $this->ticket->responses()->orderBy('created_at', 'desc')->get();
+        $this->markResponsesAsRead();
+    }
+    #[Title("")]
+    public function render()
+    {
+
+        return view('livewire.admin.support.ticket.ticket-show')
+            ->layout('components.layouts.admin');
+    }
+
+    public function send()
+    {
+        $this->validate([
+            "message" => "required"
+        ]);
+
+        $this->ticket->update([
+            "updated_at" => now()
+        ]);
+
+        $this->ticket->responses()->create([
+            "message" => $this->message,
+            "user_id" => auth()->id()
+        ]);
+        $this->message = '';
+    }
+
+    public function closeTicket()
+    {
+        $this->ticket->update([
+            "status" => "closed"
+        ]);
+    }
+
+    public function openTicket()
+    {
+        $this->ticket->update([
+            "status" => "open"
+        ]);
+    }
+
+    public function transfertToJira()
+    {
+        $ticket = Jira::issues()->create([
+            "fields" => [
+                "project" => [
+                    "key" => "VSH"
+                ],
+                "summary" => $this->ticket->title,
+                "description" => $this->ticket->responses()->first()->message,
+                "issuetype" => [
+                    "name" => "Bug"
+                ],
+                "priority" => [
+                    "name" => \Str::ucfirst($this->ticket->priority)
+                ]
+            ],
+        ]);
+
+        $this->ticket->update([
+            "jira_ticket_id" => $ticket["key"]
+        ]);
+        $this->ticket->responses()->create([
+            "message" => "Le ticket a été transféré sur Jira",
+            "user_id" => auth()->id()
+        ]);
+
+        $this->alert("success", "Le ticket a été transféré sur Jira");
+    }
+
+    public function markResponsesAsRead()
+    {
+        TicketResponse::where('ticket_id', $this->ticketId)
+            ->where('user_id',  auth()->id())
+            ->whereNull('read_at')
+            ->update(['read_at' => now()]);
+    }
+}

--- a/app/Livewire/Forms/Admin/Support/Ticket/TicketForm.php
+++ b/app/Livewire/Forms/Admin/Support/Ticket/TicketForm.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Livewire\Forms\Admin\Support\Ticket;
+
+use App\Models\Support\Ticket\Ticket;
+use App\Models\Support\Ticket\TicketCategory;
+use Livewire\Attributes\Validate;
+use Livewire\Form;
+
+class TicketForm extends Form
+{
+    public ?Ticket $ticket;
+
+    public $title = '';
+    public $priority = '';
+    public $status = '';
+    public $user_id = 0;
+    public $service_id = 0;
+    public $ticket_category_id = 0;
+    public $message = '';
+    public $selectedService = null;
+    public $ticketCategories  = [];
+    public $pushToJira = false;
+
+    public function setTicket(Ticket $ticket)
+    {
+        $this->ticket = $ticket;
+        $this->title = $ticket->title;
+        $this->priority = $ticket->priority;
+        $this->status = $ticket->status;
+        $this->user_id = $ticket->user_id;
+        $this->service_id = $ticket->service_id;
+        $this->ticket_category_id = $ticket->ticket_category_id;
+        $this->message = $ticket->responses()->first()->message;
+    }
+
+    public function save()
+    {
+        $this->validate([
+            "title" => "required",
+            "priority" => "required",
+            "user_id" => "required",
+            "selectedService" => "required",
+            "ticket_category_id" => "required",
+            "message" => "required",
+        ]);
+
+        $ticket = Ticket::create([
+            "title" => $this->title,
+            "priority" => $this->priority,
+            "status" => "open",
+            "user_id" => $this->user_id,
+            "service_id" => $this->selectedService,
+            "ticket_category_id" => $this->ticket_category_id,
+        ]);
+        $ticket->responses()->create([
+            "message" => $this->message,
+            "user_id" => auth()->id(),
+        ]);
+    }
+}

--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -2,9 +2,9 @@
 
 namespace App\Models;
 
-use App\Enum\ServiceStatusEnum;
-use App\Enum\ServiceTypeEnum;
 use App\Events\ModelCreated;
+use App\Models\Support\Ticket\Ticket;
+use App\Models\Support\Ticket\TicketCategory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Notifiable;
 
@@ -36,6 +36,15 @@ class Service extends Model
         return $this->hasMany(ServiceNote::class);
     }
 
+    public function ticket_categories()
+    {
+        return $this->hasMany(TicketCategory::class);
+    }
+
+    public function tickets()
+    {
+        return $this->hasMany(Ticket::class);
+    }
     public static function  getTypeFormat($type, $format = 'text')
     {
         return match ($format) {

--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -45,6 +45,19 @@ class Service extends Model
     {
         return $this->hasMany(Ticket::class);
     }
+
+    public static function getOptions()
+    {
+        $arr = collect();
+        $services = self::all();
+        foreach ($services as $service) {
+            $arr->push([
+                "id" => $service->id,
+                "value" => $service->name
+            ]);
+        }
+        return $arr;
+    }
     public static function  getTypeFormat($type, $format = 'text')
     {
         return match ($format) {

--- a/app/Models/Support/Ticket/Ticket.php
+++ b/app/Models/Support/Ticket/Ticket.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Models\Support\Ticket;
+
+use App\Models\Service;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Ticket extends Model
+{
+    use HasFactory;
+    use SoftDeletes;
+    protected $guarded = [];
+    protected $appends = [
+        'priority_label',
+        'status_label',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function service()
+    {
+        return $this->belongsTo(Service::class);
+    }
+
+    public function category()
+    {
+        return $this->belongsTo(TicketCategory::class, 'ticket_category_id');
+    }
+
+    public function responses()
+    {
+        return $this->hasMany(TicketResponse::class);
+    }
+
+    public function getPriorityStyle(string $style)
+    {
+        return match ($style) {
+            "icon" => match ($this->priority) {
+                "low" => "fa-angle-down",
+                "medium" => "fa-minus",
+                "high" => "fa-angle-up",
+            },
+            "text" => match ($this->priority) {
+                "low" => "Basse",
+                "medium" => "Normal",
+                "high" => "Haute",
+            },
+            "color" => match ($this->priority) {
+                "low" => "text-success",
+                "medium" => "text-primary",
+                "high" => "text-danger",
+            },
+        };
+    }
+
+    public function getStatusStyle(string $style)
+    {
+        return match ($style) {
+            "icon" => match ($this->status) {
+                "open" => "fa-circle",
+                "closed" => "fa-check-circle",
+                "pending" => "fa-clock",
+            },
+            "text" => match ($this->status) {
+                "open" => "Ouvert",
+                "closed" => "Fermé",
+                "pending" => "En attente",
+            },
+            "color" => match ($this->status) {
+                "open" => "success",
+                "closed" => "primary",
+                "pending" => "warning",
+            },
+        };
+    }
+
+    public function getPriorityLabelAttribute()
+    {
+        return "<i class='fa-solid {$this->getPriorityStyle('icon')} {$this->getPriorityStyle('color')} fs-1' data-bs-toggle='tooltip' data-bs-original-title='{$this->getPriorityStyle('text')}'></i>";
+    }
+
+    public function getStatusLabelAttribute()
+    {
+        return "<span class='badge badge-{$this->getStatusStyle('color')} text-inverse-{$this->getStatusStyle('color')}'><i class='fa-solid {$this->getStatusStyle('icon')} text-inverse-{$this->getStatusStyle('color')} me-2'></i> {$this->getStatusStyle('text')}</span>";
+    }
+}

--- a/app/Models/Support/Ticket/TicketCategory.php
+++ b/app/Models/Support/Ticket/TicketCategory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models\Support\Ticket;
+
+use App\Models\Service;
+use Illuminate\Database\Eloquent\Model;
+
+class TicketCategory extends Model
+{
+    public $timestamps = false;
+    protected $guarded = [];
+
+    public function service()
+    {
+        return $this->belongsTo(Service::class);
+    }
+
+    public function tickets()
+    {
+        return $this->hasMany(Ticket::class);
+    }
+}

--- a/app/Models/Support/Ticket/TicketLog.php
+++ b/app/Models/Support/Ticket/TicketLog.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models\Support\Ticket;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TicketLog extends Model
+{
+    protected $guarded = [];
+
+    public function ticket()
+    {
+        return $this->belongsTo(Ticket::class);
+    }
+}

--- a/app/Models/Support/Ticket/TicketResponse.php
+++ b/app/Models/Support/Ticket/TicketResponse.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models\Support\Ticket;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+
+class TicketResponse extends Model
+{
+    protected $guarded = [];
+
+    public function ticket()
+    {
+        return $this->belongsTo(Ticket::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,6 +7,8 @@ use App\Models\Social\Event;
 use App\Models\Social\Follow;
 use App\Models\Social\Post;
 use App\Models\Social\PostComment;
+use App\Models\Support\Ticket\Ticket;
+use App\Models\Support\Ticket\TicketResponse;
 use App\Models\Wiki\Wiki;
 use Creativeorange\Gravatar\Facades\Gravatar;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
@@ -118,6 +120,16 @@ class User extends Authenticatable implements MustVerifyEmail
     public function userRewards()
     {
         return $this->hasMany(UserRewards::class);
+    }
+
+    public function tickets()
+    {
+        return $this->hasMany(Ticket::class);
+    }
+
+    public function ticketResponses()
+    {
+        return $this->hasMany(TicketResponse::class);
     }
 
     public function follow(User $user)

--- a/app/Observers/TicketLogObserver.php
+++ b/app/Observers/TicketLogObserver.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Support\Ticket\TicketLog;
+use App\Notifications\System\SendMessageNotification;
+
+class TicketLogObserver
+{
+    public function created(TicketLog $ticketLog): void
+    {
+        $ticketLog->ticket->user->notify(new SendMessageNotification(
+            "Nouvelle information sur votre ticket",
+            "Une nouvelle information a été ajoutée à votre ticket. Vous pouvez la consulter en cliquant sur le bouton ci-dessous.",
+            "info",
+            "fa-info-circle",
+            "https://support.".config("app.domain")."/tickets/".$ticketLog->ticket->id
+        ));
+    }
+}

--- a/app/Observers/TicketObserver.php
+++ b/app/Observers/TicketObserver.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Support\Ticket\Ticket;
+
+class TicketObserver
+{
+    public function created(Ticket $ticket): void
+    {
+        if(auth()->user()->admin) {
+            $ticket->logs()->create(["action" => "Création du ticket par un administrateur"]);
+        } else {
+            $ticket->logs()->create(["action" => "Création du ticket"]);
+        }
+    }
+
+    public function updated(Ticket $ticket): void
+    {
+        match ($ticket->status) {
+            "open" => $ticket->logs()->create(["action" => "Le ticket a été ouvert"]),
+            "closed" => $ticket->logs()->create(["action" => "Le ticket a été fermé"]),
+            "waiting" => $ticket->logs()->create(["action" => "Le ticket est en attente"]),
+        };
+
+        match ($ticket->priority) {
+            "low" => $ticket->logs()->create(["action" => "La priorité du ticket a été mise à faible"]),
+            "medium" => $ticket->logs()->create(["action" => "La priorité du ticket a été mise à moyenne"]),
+            "high" => $ticket->logs()->create(["action" => "La priorité du ticket a été mise à haute"]),
+        };
+    }
+
+    public function deleted(Ticket $ticket): void
+    {
+        $ticket->logs()->create(["action" => "Le ticket a été supprimé"]);
+    }
+
+    public function restored(Ticket $ticket): void
+    {
+        $ticket->logs()->create(["action" => "Le ticket a été restauré"]);
+    }
+}

--- a/app/Observers/TicketResponseObserver.php
+++ b/app/Observers/TicketResponseObserver.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Support\Ticket\TicketResponse;
+use App\Notifications\System\SendMessageNotification;
+
+class TicketResponseObserver
+{
+    public function created(TicketResponse $ticketResponse): void
+    {
+        $ticketResponse->user->notify(new SendMessageNotification(
+            "Nouvelle réponse sur votre ticket",
+            "Une nouvelle réponse a été ajoutée à votre ticket. Vous pouvez la consulter en cliquant sur le bouton ci-dessous.",
+            "info",
+            "fa-info-circle",
+            "https://support.".config("app.domain")."/tickets/".$ticketResponse->ticket->id
+        ));
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -4,10 +4,16 @@ namespace App\Providers;
 
 use App\Events\ModelCreated;
 use App\Models\ServiceNote;
+use App\Models\Support\Ticket\Ticket;
+use App\Models\Support\Ticket\TicketLog;
+use App\Models\Support\Ticket\TicketResponse;
 use App\Models\User;
 use App\Models\Wiki\Wiki;
 use App\Observer\ServiceNoteObserver;
 use App\Observer\UserObserver;
+use App\Observers\TicketLogObserver;
+use App\Observers\TicketObserver;
+use App\Observers\TicketResponseObserver;
 use App\Observers\WikiObserver;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
@@ -36,6 +42,9 @@ class EventServiceProvider extends ServiceProvider
         User::observe(UserObserver::class);
         ServiceNote::observe(ServiceNoteObserver::class);
         Wiki::observe(WikiObserver::class);
+        Ticket::observe(TicketObserver::class);
+        TicketResponse::observe(TicketResponseObserver::class);
+        TicketLog::observe(TicketLogObserver::class);
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
     },
     "require-dev": {
         "fakerphp/faker": "^1.9.1",
+        "laradumps/laradumps": "^2.3",
         "laravel/pint": "^1.0",
         "laravel/sail": "*",
         "mockery/mockery": "^1.4.4",

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "anthonymartin/geo-location": "^2.0",
         "arcanedev/log-viewer": "^10.0",
         "creativeorange/gravatar": "*",
+        "devmoath/jira-laravel": "^0.1.2",
         "guzzlehttp/guzzle": "^7.2",
         "intervention/image": "^2.7",
         "ivanomatteo/laravel-device-tracking": "^0.2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aa17752e5e70df7c023361a6bafde1cc",
+    "content-hash": "06cfb56d3e6c5a3e4378a5d42be52e4e",
     "packages": [
         {
             "name": "anthonymartin/geo-location",
@@ -257,16 +257,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.295.4",
+            "version": "3.295.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "2372661db989fe4229abd95f4434b37252076d58"
+                "reference": "e3ba36c6e52dce373064fbb1741547828235425f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/2372661db989fe4229abd95f4434b37252076d58",
-                "reference": "2372661db989fe4229abd95f4434b37252076d58",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/e3ba36c6e52dce373064fbb1741547828235425f",
+                "reference": "e3ba36c6e52dce373064fbb1741547828235425f",
                 "shasum": ""
             },
             "require": {
@@ -346,9 +346,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.295.4"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.295.7"
             },
-            "time": "2023-12-29T19:07:49+00:00"
+            "time": "2024-01-05T19:10:48+00:00"
         },
         {
             "name": "bacon/bacon-qr-code",
@@ -864,6 +864,137 @@
                 "source": "https://github.com/defuse/php-encryption/tree/v2.4.0"
             },
             "time": "2023-06-19T06:10:36+00:00"
+        },
+        {
+            "name": "devmoath/jira-laravel",
+            "version": "v0.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/devmoath/jira-laravel.git",
+                "reference": "80ef5787fbb7e8d8d22622e126cb8c5c2f3db2e8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/devmoath/jira-laravel/zipball/80ef5787fbb7e8d8d22622e126cb8c5c2f3db2e8",
+                "reference": "80ef5787fbb7e8d8d22622e126cb8c5c2f3db2e8",
+                "shasum": ""
+            },
+            "require": {
+                "devmoath/jira-php": "0.*",
+                "laravel/framework": "^9.0|^10.0",
+                "php": "^8.1.0"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.2.0",
+                "pestphp/pest": "^2.0.0",
+                "pestphp/pest-plugin-mock": "^2.0.0",
+                "phpstan/extension-installer": "^1.2",
+                "phpstan/phpstan": "^1.8.6",
+                "phpstan/phpstan-strict-rules": "^1.4",
+                "rector/rector": "^0.14.4",
+                "symfony/var-dumper": "^6.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Jira\\Laravel\\ServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Jira\\Laravel\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Moath Alhajri",
+                    "email": "moath.alhajrii@gmail.com"
+                }
+            ],
+            "description": "Jira PHP for Laravel is a supercharged PHP API client that allows you to interact with the Jira API and the Service Desk API",
+            "keywords": [
+                "api",
+                "client",
+                "jira",
+                "laravel",
+                "php",
+                "sdk",
+                "service-desk"
+            ],
+            "support": {
+                "issues": "https://github.com/devmoath/jira-laravel/issues",
+                "source": "https://github.com/devmoath/jira-laravel/tree/v0.1.2"
+            },
+            "time": "2023-02-12T12:39:26+00:00"
+        },
+        {
+            "name": "devmoath/jira-php",
+            "version": "v0.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/devmoath/jira-php.git",
+                "reference": "997dad9adefe509493fd9823d9d163767b2c3470"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/devmoath/jira-php/zipball/997dad9adefe509493fd9823d9d163767b2c3470",
+                "reference": "997dad9adefe509493fd9823d9d163767b2c3470",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^7.5.0",
+                "php": "^8.1.0"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.2.0",
+                "nunomaduro/collision": "^7.0.0",
+                "pestphp/pest": "^2.0.0",
+                "pestphp/pest-plugin-mock": "^2.0.0",
+                "phpstan/extension-installer": "^1.2",
+                "phpstan/phpstan": "^1.8.6",
+                "phpstan/phpstan-strict-rules": "^1.4",
+                "rector/rector": "^0.14.4",
+                "symfony/var-dumper": "^6.2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Jira.php"
+                ],
+                "psr-4": {
+                    "Jira\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Moath Alhajri",
+                    "email": "moath.alhajrii@gmail.com"
+                }
+            ],
+            "description": "Jira PHP is a supercharged PHP API client that allows you to interact with the Jira API and the Service Desk API",
+            "keywords": [
+                "api",
+                "client",
+                "jira",
+                "php",
+                "sdk",
+                "service-desk"
+            ],
+            "support": {
+                "issues": "https://github.com/devmoath/jira-php/issues",
+                "source": "https://github.com/devmoath/jira-php/tree/v0.1.0"
+            },
+            "time": "2023-02-12T00:46:11+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -4232,35 +4363,35 @@
         },
         {
             "name": "livewire/livewire",
-            "version": "v3.3.3",
+            "version": "v3.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/livewire/livewire.git",
-                "reference": "6dd3bec8c711cd792742be4620057637e261e6f7"
+                "reference": "1ef880fbcdc7b6e5e405cc9135a62cd5fdbcd06a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/livewire/livewire/zipball/6dd3bec8c711cd792742be4620057637e261e6f7",
-                "reference": "6dd3bec8c711cd792742be4620057637e261e6f7",
+                "url": "https://api.github.com/repos/livewire/livewire/zipball/1ef880fbcdc7b6e5e405cc9135a62cd5fdbcd06a",
+                "reference": "1ef880fbcdc7b6e5e405cc9135a62cd5fdbcd06a",
                 "shasum": ""
             },
             "require": {
-                "illuminate/database": "^10.0",
-                "illuminate/support": "^10.0",
-                "illuminate/validation": "^10.0",
+                "illuminate/database": "^10.0|^11.0",
+                "illuminate/support": "^10.0|^11.0",
+                "illuminate/validation": "^10.0|^11.0",
                 "league/mime-type-detection": "^1.9",
                 "php": "^8.1",
-                "symfony/http-kernel": "^6.2"
+                "symfony/http-kernel": "^6.2|^7.0"
             },
             "require-dev": {
                 "calebporzio/sushi": "^2.1",
-                "laravel/framework": "^10.0",
+                "laravel/framework": "^10.0|^11.0",
                 "laravel/prompts": "^0.1.6",
                 "mockery/mockery": "^1.3.1",
-                "orchestra/testbench": "^8.0",
-                "orchestra/testbench-dusk": "^8.0",
-                "phpunit/phpunit": "^9.0",
-                "psy/psysh": "@stable"
+                "orchestra/testbench": "^8.0|^9.0",
+                "orchestra/testbench-dusk": "^8.0|^9.0",
+                "phpunit/phpunit": "^10.4",
+                "psy/psysh": "^0.11.22|^0.12"
             },
             "type": "library",
             "extra": {
@@ -4294,7 +4425,7 @@
             "description": "A front-end framework for Laravel.",
             "support": {
                 "issues": "https://github.com/livewire/livewire/issues",
-                "source": "https://github.com/livewire/livewire/tree/v3.3.3"
+                "source": "https://github.com/livewire/livewire/tree/v3.3.5"
             },
             "funding": [
                 {
@@ -4302,7 +4433,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-20T05:34:05+00:00"
+            "time": "2024-01-02T14:29:17+00:00"
         },
         {
             "name": "maatwebsite/excel",
@@ -4574,16 +4705,16 @@
         },
         {
             "name": "matomo/device-detector",
-            "version": "6.2.0",
+            "version": "6.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/matomo-org/device-detector.git",
-                "reference": "3577abbfea71eaf88d4cd432274428c39601754f"
+                "reference": "19138b0c4b9ddf4ffd8e423d6af3764b7317cb0b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matomo-org/device-detector/zipball/3577abbfea71eaf88d4cd432274428c39601754f",
-                "reference": "3577abbfea71eaf88d4cd432274428c39601754f",
+                "url": "https://api.github.com/repos/matomo-org/device-detector/zipball/19138b0c4b9ddf4ffd8e423d6af3764b7317cb0b",
+                "reference": "19138b0c4b9ddf4ffd8e423d6af3764b7317cb0b",
                 "shasum": ""
             },
             "require": {
@@ -4595,8 +4726,8 @@
             },
             "require-dev": {
                 "matthiasmullie/scrapbook": "^1.4.7",
-                "mayflower/mo4-coding-standard": "^v8.0.0",
-                "phpstan/phpstan": "^0.12.52",
+                "mayflower/mo4-coding-standard": "^v9.0.0",
+                "phpstan/phpstan": "^1.10.44",
                 "phpunit/phpunit": "^8.5.8",
                 "psr/cache": "^1.0.1",
                 "psr/simple-cache": "^1.0.1",
@@ -4639,7 +4770,7 @@
                 "source": "https://github.com/matomo-org/matomo",
                 "wiki": "https://dev.matomo.org/"
             },
-            "time": "2023-11-15T09:44:42+00:00"
+            "time": "2024-01-05T09:03:21+00:00"
         },
         {
             "name": "mews/captcha",
@@ -10421,23 +10552,23 @@
         },
         {
             "name": "web-token/jwt-core",
-            "version": "3.2.8",
+            "version": "3.2.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/web-token/jwt-core.git",
-                "reference": "2bc6e99a60910d0f495682acd8b23d3eef9865a3"
+                "reference": "2b7277a4837230cf2982a1484643a978d505eae3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/web-token/jwt-core/zipball/2bc6e99a60910d0f495682acd8b23d3eef9865a3",
-                "reference": "2bc6e99a60910d0f495682acd8b23d3eef9865a3",
+                "url": "https://api.github.com/repos/web-token/jwt-core/zipball/2b7277a4837230cf2982a1484643a978d505eae3",
+                "reference": "2b7277a4837230cf2982a1484643a978d505eae3",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "^0.9|^0.10|^0.11",
+                "brick/math": "^0.9|^0.10|^0.11|^0.12",
                 "ext-json": "*",
                 "ext-mbstring": "*",
-                "paragonie/constant_time_encoding": "^2.4",
+                "paragonie/constant_time_encoding": "^2.6",
                 "php": ">=8.1",
                 "spomky-labs/pki-framework": "^1.0"
             },
@@ -10485,7 +10616,7 @@
                 "symfony"
             ],
             "support": {
-                "source": "https://github.com/web-token/jwt-core/tree/3.2.8"
+                "source": "https://github.com/web-token/jwt-core/tree/3.2.9"
             },
             "funding": [
                 {
@@ -10493,20 +10624,20 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2023-08-23T09:49:09+00:00"
+            "time": "2024-01-04T15:42:08+00:00"
         },
         {
             "name": "web-token/jwt-key-mgmt",
-            "version": "3.2.8",
+            "version": "3.2.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/web-token/jwt-key-mgmt.git",
-                "reference": "3b51eeeff38ac58ee86ec83d073b88b8294b1c7e"
+                "reference": "2a034fdbf5142e39152b62cde066d2e707cfacb9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/web-token/jwt-key-mgmt/zipball/3b51eeeff38ac58ee86ec83d073b88b8294b1c7e",
-                "reference": "3b51eeeff38ac58ee86ec83d073b88b8294b1c7e",
+                "url": "https://api.github.com/repos/web-token/jwt-key-mgmt/zipball/2a034fdbf5142e39152b62cde066d2e707cfacb9",
+                "reference": "2a034fdbf5142e39152b62cde066d2e707cfacb9",
                 "shasum": ""
             },
             "require": {
@@ -10563,7 +10694,7 @@
                 "symfony"
             ],
             "support": {
-                "source": "https://github.com/web-token/jwt-key-mgmt/tree/3.2.8"
+                "source": "https://github.com/web-token/jwt-key-mgmt/tree/3.2.9"
             },
             "funding": [
                 {
@@ -10571,20 +10702,20 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2023-05-18T16:20:51+00:00"
+            "time": "2024-01-04T15:42:08+00:00"
         },
         {
             "name": "web-token/jwt-signature",
-            "version": "3.2.8",
+            "version": "3.2.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/web-token/jwt-signature.git",
-                "reference": "156e0b0ef534e53eecf23a32a92ee6d8cb4fdac4"
+                "reference": "14fec03d581550396edd0bf20fe6308dac167165"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/web-token/jwt-signature/zipball/156e0b0ef534e53eecf23a32a92ee6d8cb4fdac4",
-                "reference": "156e0b0ef534e53eecf23a32a92ee6d8cb4fdac4",
+                "url": "https://api.github.com/repos/web-token/jwt-signature/zipball/14fec03d581550396edd0bf20fe6308dac167165",
+                "reference": "14fec03d581550396edd0bf20fe6308dac167165",
                 "shasum": ""
             },
             "require": {
@@ -10640,7 +10771,7 @@
                 "symfony"
             ],
             "support": {
-                "source": "https://github.com/web-token/jwt-signature/tree/3.2.8"
+                "source": "https://github.com/web-token/jwt-signature/tree/3.2.9"
             },
             "funding": [
                 {
@@ -10648,20 +10779,20 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2023-05-18T16:20:51+00:00"
+            "time": "2024-01-04T15:42:08+00:00"
         },
         {
             "name": "web-token/jwt-signature-algorithm-ecdsa",
-            "version": "3.2.8",
+            "version": "3.2.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/web-token/jwt-signature-algorithm-ecdsa.git",
-                "reference": "34b119d6b5eca53914ad3b96660e5bd7fb5538b9"
+                "reference": "3d9c9fdca24376845bfb9a1ae46d63c1f7b395b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/web-token/jwt-signature-algorithm-ecdsa/zipball/34b119d6b5eca53914ad3b96660e5bd7fb5538b9",
-                "reference": "34b119d6b5eca53914ad3b96660e5bd7fb5538b9",
+                "url": "https://api.github.com/repos/web-token/jwt-signature-algorithm-ecdsa/zipball/3d9c9fdca24376845bfb9a1ae46d63c1f7b395b7",
+                "reference": "3d9c9fdca24376845bfb9a1ae46d63c1f7b395b7",
                 "shasum": ""
             },
             "require": {
@@ -10710,7 +10841,7 @@
                 "symfony"
             ],
             "support": {
-                "source": "https://github.com/web-token/jwt-signature-algorithm-ecdsa/tree/3.2.8"
+                "source": "https://github.com/web-token/jwt-signature-algorithm-ecdsa/tree/3.2.9"
             },
             "funding": [
                 {
@@ -10718,24 +10849,24 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2023-05-18T16:20:51+00:00"
+            "time": "2024-01-02T17:55:33+00:00"
         },
         {
             "name": "web-token/jwt-util-ecc",
-            "version": "3.2.8",
+            "version": "3.2.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/web-token/jwt-util-ecc.git",
-                "reference": "b2337052dbee724d710c1fdb0d3609835a5f8609"
+                "reference": "9edf9b76bccf2e1db58fcc49db1d916d929335c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/web-token/jwt-util-ecc/zipball/b2337052dbee724d710c1fdb0d3609835a5f8609",
-                "reference": "b2337052dbee724d710c1fdb0d3609835a5f8609",
+                "url": "https://api.github.com/repos/web-token/jwt-util-ecc/zipball/9edf9b76bccf2e1db58fcc49db1d916d929335c0",
+                "reference": "9edf9b76bccf2e1db58fcc49db1d916d929335c0",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "^0.9|^0.10|^0.11",
+                "brick/math": "^0.9|^0.10|^0.11|^0.12",
                 "php": ">=8.1"
             },
             "suggest": {
@@ -10783,7 +10914,7 @@
                 "symfony"
             ],
             "support": {
-                "source": "https://github.com/web-token/jwt-util-ecc/tree/3.2.8"
+                "source": "https://github.com/web-token/jwt-util-ecc/tree/3.2.9"
             },
             "funding": [
                 {
@@ -10791,7 +10922,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2023-02-02T13:35:41+00:00"
+            "time": "2024-01-02T17:55:33+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -10913,16 +11044,16 @@
     "packages-dev": [
         {
             "name": "fakerphp/faker",
-            "version": "v1.23.0",
+            "version": "v1.23.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FakerPHP/Faker.git",
-                "reference": "e3daa170d00fde61ea7719ef47bb09bb8f1d9b01"
+                "reference": "bfb4fe148adbf78eff521199619b93a52ae3554b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/e3daa170d00fde61ea7719ef47bb09bb8f1d9b01",
-                "reference": "e3daa170d00fde61ea7719ef47bb09bb8f1d9b01",
+                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/bfb4fe148adbf78eff521199619b93a52ae3554b",
+                "reference": "bfb4fe148adbf78eff521199619b93a52ae3554b",
                 "shasum": ""
             },
             "require": {
@@ -10948,11 +11079,6 @@
                 "ext-mbstring": "Required for multibyte Unicode string functionality."
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "v1.21-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Faker\\": "src/Faker/"
@@ -10975,9 +11101,9 @@
             ],
             "support": {
                 "issues": "https://github.com/FakerPHP/Faker/issues",
-                "source": "https://github.com/FakerPHP/Faker/tree/v1.23.0"
+                "source": "https://github.com/FakerPHP/Faker/tree/v1.23.1"
             },
-            "time": "2023-06-12T08:44:38+00:00"
+            "time": "2024-01-02T13:46:09+00:00"
         },
         {
             "name": "filp/whoops",
@@ -13052,16 +13178,16 @@
         },
         {
             "name": "spatie/ignition",
-            "version": "1.11.3",
+            "version": "1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/ignition.git",
-                "reference": "3d886de644ff7a5b42e4d27c1e1f67c8b5f00044"
+                "reference": "5b6f801c605a593106b623e45ca41496a6e7d56d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/ignition/zipball/3d886de644ff7a5b42e4d27c1e1f67c8b5f00044",
-                "reference": "3d886de644ff7a5b42e4d27c1e1f67c8b5f00044",
+                "url": "https://api.github.com/repos/spatie/ignition/zipball/5b6f801c605a593106b623e45ca41496a6e7d56d",
+                "reference": "5b6f801c605a593106b623e45ca41496a6e7d56d",
                 "shasum": ""
             },
             "require": {
@@ -13131,39 +13257,39 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-10-18T14:09:40+00:00"
+            "time": "2024-01-03T15:49:39+00:00"
         },
         {
             "name": "spatie/laravel-ignition",
-            "version": "2.3.3",
+            "version": "2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-ignition.git",
-                "reference": "66499cd3c858642ded56dafb8fa0352057ca20dd"
+                "reference": "b9395ba48d3f30d42092cf6ceff75ed7256cd604"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-ignition/zipball/66499cd3c858642ded56dafb8fa0352057ca20dd",
-                "reference": "66499cd3c858642ded56dafb8fa0352057ca20dd",
+                "url": "https://api.github.com/repos/spatie/laravel-ignition/zipball/b9395ba48d3f30d42092cf6ceff75ed7256cd604",
+                "reference": "b9395ba48d3f30d42092cf6ceff75ed7256cd604",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
                 "ext-json": "*",
                 "ext-mbstring": "*",
-                "illuminate/support": "^10.0",
+                "illuminate/support": "^10.0|^11.0",
                 "php": "^8.1",
                 "spatie/flare-client-php": "^1.3.5",
                 "spatie/ignition": "^1.9",
-                "symfony/console": "^6.2.3",
-                "symfony/var-dumper": "^6.2.3"
+                "symfony/console": "^6.2.3|^7.0",
+                "symfony/var-dumper": "^6.2.3|^7.0"
             },
             "require-dev": {
-                "livewire/livewire": "^2.11",
+                "livewire/livewire": "^2.11|^3.3.5",
                 "mockery/mockery": "^1.5.1",
-                "openai-php/client": "^0.3.4",
-                "orchestra/testbench": "^8.0",
-                "pestphp/pest": "^1.22.3",
+                "openai-php/client": "^0.8.1",
+                "orchestra/testbench": "^8.0|^9.0",
+                "pestphp/pest": "^2.30",
                 "phpstan/extension-installer": "^1.2",
                 "phpstan/phpstan-deprecation-rules": "^1.1.1",
                 "phpstan/phpstan-phpunit": "^1.3.3",
@@ -13223,7 +13349,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-21T09:43:05+00:00"
+            "time": "2024-01-04T14:51:24+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -13358,5 +13484,5 @@
         "php": "^8.1"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "06cfb56d3e6c5a3e4378a5d42be52e4e",
+    "content-hash": "8292c41158d10f4dd7ae34b51a48e767",
     "packages": [
         {
             "name": "anthonymartin/geo-location",
@@ -11226,6 +11226,143 @@
                 "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.0.1"
             },
             "time": "2020-07-09T08:09:16+00:00"
+        },
+        {
+            "name": "laradumps/laradumps",
+            "version": "v2.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laradumps/laradumps.git",
+                "reference": "e981115f7a12e01e60715c45044ac0540088d92d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laradumps/laradumps/zipball/e981115f7a12e01e60715c45044ac0540088d92d",
+                "reference": "e981115f7a12e01e60715c45044ac0540088d92d",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/mail": "^9.0|^10.0",
+                "illuminate/support": "^9.0|^10.0",
+                "laradumps/laradumps-core": "^1.0",
+                "nunomaduro/termwind": "^1.15.1",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "larastan/larastan": "^2.7",
+                "laravel/pint": "^1.13.7",
+                "orchestra/testbench": "^8.17",
+                "pestphp/pest": "^2.28.1",
+                "symfony/var-dumper": "^6.4.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "LaraDumps\\LaraDumps\\LaraDumpsServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "LaraDumps\\LaraDumps\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Luan Freitas",
+                    "email": "luanfreitas10@protonmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A Dump Component for Laravel.",
+            "homepage": "https://github.com/laradumps/laradumps",
+            "support": {
+                "issues": "https://github.com/laradumps/laradumps/issues",
+                "source": "https://github.com/laradumps/laradumps/tree/v2.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/luanfreitasdev",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-30T20:04:05+00:00"
+        },
+        {
+            "name": "laradumps/laradumps-core",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laradumps/laradumps-core.git",
+                "reference": "00bb99f7c3c5585e8a9e1221ff5541f58fe412b2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laradumps/laradumps-core/zipball/00bb99f7c3c5585e8a9e1221ff5541f58fe412b2",
+                "reference": "00bb99f7c3c5585e8a9e1221ff5541f58fe412b2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "nesbot/carbon": "^2.72",
+                "nunomaduro/termwind": "^1.15|^2.0",
+                "php": "^8.1",
+                "ramsey/uuid": "^4.7.5",
+                "symfony/console": "^6.4|^7.0",
+                "symfony/finder": "^6.4|^7.0",
+                "symfony/process": "^6.4|^7.0",
+                "symfony/var-dumper": "^6.4|^7.0",
+                "vlucas/phpdotenv": "^5.6"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.13.7",
+                "pestphp/pest": "^2.28.1",
+                "phpstan/phpstan": "^1.10.50"
+            },
+            "bin": [
+                "bin/laradumps"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "LaraDumps\\LaraDumpsCore\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Luan Freitas",
+                    "email": "luanfreitas10@protonmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A dump component for php code.",
+            "homepage": "https://github.com/laradumps/laradumps-core",
+            "support": {
+                "issues": "https://github.com/laradumps/laradumps-core/issues",
+                "source": "https://github.com/laradumps/laradumps-core/tree/v1.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/luanfreitasdev",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-28T18:04:20+00:00"
         },
         {
             "name": "laravel/pint",

--- a/config/jira.php
+++ b/config/jira.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Jira
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify your username, password, and jira host.
+    */
+
+    'username' => env('JIRA_USERNAME'),
+    'password' => env('JIRA_PASSWORD'),
+    'host' => env('JIRA_HOST'),
+
+];

--- a/database/factories/Support/Ticket/TicketFactory.php
+++ b/database/factories/Support/Ticket/TicketFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Database\Factories\Support\Ticket;
+
+use App\Models\Service;
+use App\Models\Support\Ticket\Ticket;
+use App\Models\Support\Ticket\TicketCategory;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Carbon;
+
+class TicketFactory extends Factory
+{
+    protected $model = Ticket::class;
+
+    public function definition(): array
+    {
+        $status = $this->faker->randomElement(['open', 'closed', 'pending']);
+        $priority = $this->faker->randomElement(['low', 'medium', 'high']);
+        $user = User::all()->random();
+        $service = Service::all()->random();
+        $category = TicketCategory::where('service_id', $service->id)->get()->random();
+        return [
+            'title' => $this->faker->word(),
+            'status' => $status,
+            'priority' => $priority,
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
+
+            'user_id' => $user->id,
+            'service_id' => $service->id,
+            'ticket_category_id' => $category->id,
+        ];
+    }
+}

--- a/database/migrations/2024_01_07_100531_create_ticket_categories_table.php
+++ b/database/migrations/2024_01_07_100531_create_ticket_categories_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('ticket_categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+
+            $table->foreignId('service_id')
+               ->constrained()
+               ->cascadeOnUpdate()
+               ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ticket_categories');
+    }
+};

--- a/database/migrations/2024_01_07_100800_create_tickets_table.php
+++ b/database/migrations/2024_01_07_100800_create_tickets_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('tickets', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->enum('status', ["open","closed","pending"])->default('open');
+            $table->enum('priority', ["low","medium","high"])->default('medium');
+            $table->softDeletes();
+            $table->timestamps();
+
+            $table->foreignId('user_id')
+               ->constrained()
+               ->cascadeOnUpdate()
+               ->cascadeOnDelete();
+
+            $table->foreignId('service_id')
+               ->constrained()
+               ->cascadeOnUpdate()
+               ->cascadeOnDelete();
+
+            $table->foreignId('ticket_category_id')
+               ->constrained()
+               ->cascadeOnUpdate()
+               ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tickets');
+    }
+};

--- a/database/migrations/2024_01_07_101101_create_ticket_responses_table.php
+++ b/database/migrations/2024_01_07_101101_create_ticket_responses_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('ticket_responses', function (Blueprint $table) {
+            $table->id();
+            $table->text('message');
+            $table->timestamps();
+
+            $table->foreignId('user_id')
+               ->constrained()
+               ->cascadeOnUpdate()
+               ->cascadeOnDelete();
+
+            $table->foreignId('ticket_id')
+               ->constrained()
+               ->cascadeOnUpdate()
+               ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ticket_responses');
+    }
+};

--- a/database/migrations/2024_01_07_111229_add_icon_to_ticket_categories_table.php
+++ b/database/migrations/2024_01_07_111229_add_icon_to_ticket_categories_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('ticket_categories', function (Blueprint $table) {
+            $table->string('icon')->nullable()->after('name');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('ticket_categories', function (Blueprint $table) {
+            $table->dropColumn('icon');
+        });
+    }
+};

--- a/database/migrations/2024_01_07_131529_create_ticket_logs_table.php
+++ b/database/migrations/2024_01_07_131529_create_ticket_logs_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('ticket_logs', function (Blueprint $table) {
+            $table->id();
+            $table->string('action');
+            $table->timestamps();
+
+            $table->foreignId('ticket_id')
+               ->constrained()
+               ->cascadeOnUpdate()
+               ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ticket_logs');
+    }
+};

--- a/database/migrations/2024_01_07_153414_add_jira_ticket_id_to_tickets_table.php
+++ b/database/migrations/2024_01_07_153414_add_jira_ticket_id_to_tickets_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('tickets', function (Blueprint $table) {
+            $table->string("jira_ticket_id")->nullable()->after("status");
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('tickets', function (Blueprint $table) {
+            $table->dropColumn("jira_ticket_id");
+        });
+    }
+};

--- a/database/migrations/2024_01_07_184320_add_read_at_to_ticket_responses_table.php
+++ b/database/migrations/2024_01_07_184320_add_read_at_to_ticket_responses_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('ticket_responses', function (Blueprint $table) {
+            $table->timestamp('read_at')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('ticket_responses', function (Blueprint $table) {
+            $table->dropColumn('read_at');
+        });
+    }
+};

--- a/database/seeders/InstallSeeder.php
+++ b/database/seeders/InstallSeeder.php
@@ -13,6 +13,7 @@ use Database\Seeders\Railway\RentalSeeder;
 use Database\Seeders\Railway\ResearchCategorySeeder;
 use Database\Seeders\Railway\SettingSeeder;
 use Database\Seeders\Social\CercleSeeder;
+use Database\Seeders\Support\TicketCategorySeeder;
 use Database\Seeders\Wiki\WikiCategorySeeder;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Artisan;
@@ -69,6 +70,7 @@ class InstallSeeder extends Seeder
         $this->call(WikiCategorySeeder::class);
         $this->call(BanqueSeeder::class);
         $this->call(ResearchCategorySeeder::class);
+        $this->call(TicketCategorySeeder::class);
 
         if(!User::where('email', "admin@".config('app.domain'))->exists()) {
             User::create([

--- a/database/seeders/Support/TicketCategorySeeder.php
+++ b/database/seeders/Support/TicketCategorySeeder.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Database\Seeders\Support;
+
+use App\Models\Support\Ticket\TicketCategory;
+use Illuminate\Database\Seeder;
+
+class TicketCategorySeeder extends Seeder
+{
+    public function run(): void
+    {
+        TicketCategory::create([
+            "service_id" => 1,
+            "name" => "Problème de connexion",
+            "icon" => "fa-wifi"
+        ]);
+
+        TicketCategory::create([
+            "service_id" => 1,
+            "name" => "Problème de facturation",
+            "icon" => "fa-money-bill-wave"
+        ]);
+
+        TicketCategory::create([
+            "service_id" => 1,
+            "name" => "Problème de paiement",
+            "icon" => "fa-credit-card"
+        ]);
+
+        TicketCategory::create([
+            "service_id" => 1,
+            "name" => "Problème de fonctionnement",
+            "icon" => "fa-cogs"
+        ]);
+
+        TicketCategory::create([
+            "service_id" => 1,
+            "name" => "Problème de sécurité",
+            "icon" => "fa-shield-alt"
+        ]);
+
+        TicketCategory::create([
+            "service_id" => 2,
+            "name" => "Problème générale",
+            'icon' => 'fa-cogs'
+        ]);
+
+        TicketCategory::create([
+            "service_id" => 2,
+            "name" => "Problème de sécurité",
+            'icon' => 'fa-shield-alt'
+        ]);
+
+        TicketCategory::create([
+            "service_id" => 2,
+            "name" => "Problème de fonctionnement",
+            'icon' => 'fa-cogs'
+        ]);
+
+        TicketCategory::create([
+            "service_id" => 3,
+            "name" => "Problème générale",
+            'icon' => 'fa-cogs'
+        ]);
+
+        TicketCategory::create([
+            "service_id" => 3,
+            "name" => "Problème de sécurité",
+            'icon' => 'fa-shield-alt'
+        ]);
+
+        TicketCategory::create([
+            "service_id" => 3,
+            "name" => "Problème de fonctionnement",
+            'icon' => 'fa-cogs'
+        ]);
+
+        TicketCategory::create([
+            "service_id" => 4,
+            "name" => "Problème générale",
+            'icon' => 'fa-cogs'
+        ]);
+
+        TicketCategory::create([
+            "service_id" => 4,
+            "name" => "Problème de sécurité",
+            'icon' => 'fa-shield-alt'
+        ]);
+
+        TicketCategory::create([
+            "service_id" => 4,
+            "name" => "Problème de fonctionnement",
+            'icon' => 'fa-cogs'
+        ]);
+    }
+}

--- a/database/seeders/TestSeeder.php
+++ b/database/seeders/TestSeeder.php
@@ -7,6 +7,7 @@ use App\Enum\BlogCategoryEnum;
 use App\Enum\BlogSubcategoryEnum;
 use App\Models\Blog;
 use App\Models\Social\Cercle;
+use App\Models\Support\Ticket\Ticket;
 use App\Models\User;
 use App\Models\Wiki\Wiki;
 use Illuminate\Database\Seeder;
@@ -72,5 +73,9 @@ class TestSeeder extends Seeder
         \Storage::disk('public')->deleteDirectory('/engine/motrice');
         \Storage::disk('public')->deleteDirectory('/engine/voiture');
         \Storage::disk('public')->deleteDirectory('/engine/bus');
+
+        Ticket::withoutEvents(function () {
+            Ticket::factory(rand(1,25))->create();
+        });
     }
 }

--- a/database/seeders/TestSeeder.php
+++ b/database/seeders/TestSeeder.php
@@ -75,7 +75,7 @@ class TestSeeder extends Seeder
         \Storage::disk('public')->deleteDirectory('/engine/bus');
 
         Ticket::withoutEvents(function () {
-            Ticket::factory(rand(1,25))->create();
+            Ticket::factory(random_int(1,25))->create();
         });
     }
 }

--- a/resources/views/livewire/admin/support/bug/bug-list.blade.php
+++ b/resources/views/livewire/admin/support/bug/bug-list.blade.php
@@ -1,3 +1,120 @@
 <div>
-    {{-- Be like water. --}}
+    <div class="card shadow-lg">
+        <div class="card-header">
+            <div class="card-title">Liste des bugs répertoriés</div>
+            <div class="card-toolbar">
+                <div class="me-2">
+                    <input type="text" class="form-control" wire:model.live.debounce.500ms="search" placeholder="Rechercher...">
+                </div>
+                <div class="me-2">
+                    <select class="form-select" wire:model.change="statusFilter">
+                        <option value="">Tous les statuts</option>
+                        <option value="Done">Terminer</option>
+                        <option value="Open">Ouvert</option>
+                        <option value="Pending">En attente</option>
+                        <option value="Reopen">Ticket Réouvert</option>
+                        <option value="Work in Progress">En cours</option>
+                    </select>
+                </div>
+                <div class="me-2">
+                    <select class="form-select" wire:model.change="priorityFilter">
+                        <option value="">Toutes les priorités</option>
+                        <option value="Lowest">Mineur</option>
+                        <option value="Low">Basse</option>
+                        <option value="Medium">Normal</option>
+                        <option value="High">Haute</option>
+                        <option value="Highest">Urgente</option>
+                    </select>
+                </div>
+                <div class="me-2">
+                    <select class="form-select" wire:model.change="composantFilter">
+                        <option value="">Toutes les composants</option>
+                        <option value="Auth Vortech Studio">Plateforme Auth</option>
+                        <option value="Railway Manager">Railway Manager</option>
+                        <option value="VortechLab">VortechLab</option>
+                    </select>
+                </div>
+                <div class="mx-2">
+                    <button class="btn btn-sm btn-icon btn-outline btn-outline-dark" wire:click="refreshFilter" data-bs-toggle="tooltip" data-bs-original-title="Rafraichir le filtrage">
+                        <i class="fa-solid fa-refresh"></i>
+                    </button>
+                </div>
+            </div>
+        </div>
+        <div class="card-body">
+            @if(count($bugs) > 0)
+                <div class="table-responsive" wire:loading.class="opacity-50 bg-grey-700 table-loading">
+                    <div class="table-loading-message">
+                        <span class="spinner-border spinner-border-sm align-middle me-2"></span> Chargement...
+                    </div>
+                    <table class="table table-row-bordered table-striped table-row-gray-500 border gap-2 gs-5 gx-5 gy-5 align-middle">
+                        <thead>
+                        <tr class="fw-bolder fs-3">
+                            <th class="w-50px"></th>
+                            <th>Designation</th>
+                            <th>Etat</th>
+                            <th>Date</th>
+                            <th>Actions</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        @foreach($bugs as $bug)
+                            <tr>
+                                <td class="border border-right-1 border-gray-500">
+                                    <div class="symbol symbol-30px symbol-circle" data-bs-toggle="tooltip" data-bs-original-title="{{ $bug['fields']['priority']['name'] }}">
+                                        <img src="{{ $bug['fields']['priority']['iconUrl'] }}" alt="">
+                                    </div>
+                                </td>
+                                <td class="border border-right-1 border-gray-500 w-25">
+                                    <div class="d-flex flex-column">
+                                        <span class="fw-bold mb-2 fs-3">{{ $bug['fields']['summary'] }}</span>
+                                        <div class="d-flex flex-row align-items-center">
+                                            @if($bug['fields']['components'])
+                                                @foreach($bug['fields']['components'] as $component)
+                                                    <div class="badge badge-secondary me-1" data-bs-toggle="tooltip" data-bs-original-title="{{ $component['description'] }}">{{ $component['name'] }}</div>
+                                                @endforeach
+                                            @endif
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="border border-right-1 border-gray-500 w-250px">
+                                    <div class="d-flex flex-row align-items-center">
+                                        <div class="symbol symbol-30px symbol-circle me-2">
+                                            <img src="{{ $bug['fields']['status']['iconUrl'] }}" alt="">
+                                        </div>
+                                        <div class="d-flex flex-column">
+                                            <span class="fw-bold">{{ $bug['fields']['status']['name'] }}</span>
+                                            <div class="fs-8 text-muted">{{ $bug['fields']['status']['description'] }}</div>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="border border-right-1 border-gray-500">
+                                    <div class="d-flex flex-column">
+                                        <div>
+                                            <span class="fw-bold me-2">Créer le:</span>
+                                            <span class="text-muted">{{ \Carbon\Carbon::createFromTimestamp(strtotime($bug['fields']['created']))->format('d/m/Y à H:i') }}</span>
+                                        </div>
+                                        <div>
+                                            <span class="fw-bold me-2">Mise à jour le:</span>
+                                            <span class="text-muted">{{ \Carbon\Carbon::createFromTimestamp(strtotime($bug['fields']['updated']))->format('d/m/Y à H:i') }}</span>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="border border-right-1 border-gray-500">
+                                    <a target="_blank" href="https://vortechstudio.atlassian.net/jira/servicedesk/projects/VSH/queues/custom/39/{{ $bug['key'] }}" class="btn btn-sm btn-icon btn-outline btn-outline-dark">
+                                        <i class="fa-solid fa-external-link"></i>
+                                    </a>
+                                </td>
+                            </tr>
+                        @endforeach
+                        </tbody>
+                    </table>
+
+                </div>
+            @else
+                <x-base.is-null
+                text="Aucun bug répertorié pour le moment." />
+            @endif
+        </div>
+    </div>
 </div>

--- a/resources/views/livewire/admin/support/ticket/ticket-chat.blade.php
+++ b/resources/views/livewire/admin/support/ticket/ticket-chat.blade.php
@@ -1,0 +1,40 @@
+<div>
+    @if($responses->count() > 0)
+        <div class="card-body scroll-y me-n5 h-300px h-lg-auto" wire:poll.keep-alive>
+            @foreach($responses as $response)
+                <div class="d-flex {{ $response->user_id != auth()->id() ? 'justify-content-start' : 'justify-content-end' }} mb-10">
+                    <div class="d-flex flex-column align-items-{{ $response->user_id != auth()->id() ? 'start' : 'end' }}">
+                        <!--begin::User-->
+                        <div class="d-flex align-items-center mb-2">
+                            <!--begin::Avatar-->
+                            <div class="symbol symbol-35px symbol-circle">
+                                <img alt="Pic" src="{{ $response->user->avatar }}" />
+                            </div>
+                            <!--end::Avatar-->
+                            <!--begin::Details-->
+                            <div class="ms-3">
+                                <a href="#" class="fs-5 fw-bold text-gray-900 text-hover-primary me-1">{{ $response->user->name }}</a>
+                                <span class="text-muted fs-7 mb-1">{{ $response->created_at->longRelativeDiffForHumans() }}</span>
+                            </div>
+                            <!--end::Details-->
+                        </div>
+                        <!--end::User-->
+                        <!--begin::Text-->
+                        <div class="p-5 rounded bg-light-info text-dark fw-semibold mw-lg-400px text-start" data-kt-element="message-text">{!! $response->message !!}</div>
+                        @if($response->read_at)
+                            <div class="pt-0 fs-8">
+                                <i class="fa-solid fa-check fs-8" data-bs-toggle="tooltip" data-bs-original-title="Vu"></i>
+                            </div>
+                        @endif
+                        <!--end::Text-->
+                    </div>
+                </div>
+            @endforeach
+        </div>
+    @else
+        <div class="card-body">
+            <x-base.is-null
+                text="Aucune réponse pour le moment" />
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/admin/support/ticket/ticket-list.blade.php
+++ b/resources/views/livewire/admin/support/ticket/ticket-list.blade.php
@@ -1,52 +1,145 @@
 <div>
-    <div class="card shadow-lg">
-        <div class="card-header">
-            <div class="card-title">
-                <i class="fa-solid fa-ticket fs-1 me-3"></i> Liste des tickets de support
-            </div>
-            <div class="card-toolbar d-flex flex-wrap align-items-center">
-                <div class="me-2">
-                    <input type="text" class="form-control" wire:model.live.debounce.500ms="search" placeholder="Rechercher...">
-                </div>
-                <div class="me-2">
-                    <select class="form-select" wire:model.change="statusFilter">
-                        <option value="">Tous les statuts</option>
-                        <option value="open">Ouvert</option>
-                        <option value="pending">En attente</option>
-                        <option value="closed">Fermé</option>
-                    </select>
-                </div>
-                <div class="me-2">
-                    <select class="form-select" wire:model.change="priorityFilter">
-                        <option value="">Toutes les priorités</option>
-                        <option value="low">Basse</option>
-                        <option value="medium">Moyenne</option>
-                        <option value="high">Haute</option>
-                    </select>
-                </div>
-                <div class="me-2">
-                    <select class="form-select" wire:model.change="serviceFilter">
-                        <option value="">Tous les services</option>
-                        @foreach(\App\Models\Service::all() as $service)
-                            <option value="{{ $service->id }}">{{ $service->name }}</option>
-                        @endforeach
-                    </select>
-                </div>
-                <div class="mx-2">
-                    <button class="btn btn-sm btn-icon btn-primary">
-                        <i class="fa-solid fa-plus"></i>
+    @if($createForm)
+        <div class="card shadow-lg">
+            <div class="card-header">
+                <div class="card-title">Création du ticket de support manuel</div>
+                <div class="card-toolbar">
+                    <button class="btn btn-sm btn-outline btn-outline-dark" wire:click="hideCreateForm">
+                        <i class="fa-solid fa-times me-2"></i> Annuler
                     </button>
                 </div>
             </div>
-        </div>
-        <div class="card-body">
-            @if($tickets->count() > 0)
-                <div class="table-responsive" wire:loading.class="opacity-50 bg-grey-700 table-loading">
-                    <div class="table-loading-message">
-                        <span class="spinner-border spinner-border-sm align-middle me-2"></span> Chargement...
+            <div class="card-body">
+                <form action="" wire:submit.prevent="createTicket">
+                    @csrf
+                    <div class="row g-3">
+                        <div class="col-sm-12 col-lg-9 mb-10">
+                            <x-form.input
+                                name="title"
+                                label="Titre du ticket"
+                                required="true"
+                                is-model="true"
+                                model="form" />
+
+                            <x-form.textarea
+                                name="message"
+                                label="Description principal du ticket"
+                                required="true"
+                                is-model="true"
+                                type="tinymce"
+                                model="form" />
+
+
+                        </div>
+                        <div class="col-sm-12 col-lg-3 mb-10">
+                            <div class="mb-10">
+                                <label for="selectedService" class="form-label required">Services</label>
+                                <select class="form-select" wire:model.change="form.selectedService">
+                                    <option value=""></option>
+                                    @foreach(\App\Models\Service::all() as $service)
+                                        <option value="{{ $service->id }}">{{ $service->name }}</option>
+                                    @endforeach
+                                </select>
+                            </div>
+
+                            @if(!empty($form->ticketCategories))
+                                <div class="mb-10">
+                                    <label for="ticket_category_id" class="form-label required">Catégorie</label>
+                                    <select class="form-select" id="ticket_category_id" wire:model.change="form.ticket_category_id">
+                                        <option value=""></option>
+                                        @foreach($form->ticketCategories as $category)
+                                            <option value="{{ $category->id }}">{{ $category->name }}</option>
+                                        @endforeach
+                                    </select>
+                                </div>
+                            @endif
+                            <div class="mb-10">
+                                <label for="priority" class="form-label required">Priorité</label>
+                                <select class="form-select" wire:model="form.priority">
+                                    <option value=""></option>
+                                    <option value="low">Basse</option>
+                                    <option value="medium">Normal</option>
+                                    <option value="high">Haute</option>
+                                </select>
+                            </div>
+                            <div class="mb-10">
+                                <label for="user_id" class="form-label required">Utilisateur concerné</label>
+                                <select class="form-select" id="user_id" wire:model="form.user_id">
+                                    <option value=""></option>
+                                    @foreach(\App\Models\User::all() as $user)
+                                        <option value="{{ $user->id }}">{{ $user->name }}</option>
+                                    @endforeach
+                                </select>
+                            </div>
+                            <x-form.checkbox
+                                name="pushToJira"
+                                label="Créer le ticket sur Jira"
+                                is-model="true"
+                                model="form" />
+
+                            <div class="d-flex flex-end">
+                                <x-form.button text-submit="Créer le ticket" />
+                            </div>
+
+                        </div>
                     </div>
-                    <table class="table table-row-bordered table-striped table-row-gray-500 border gap-2 gs-5 gx-5 gy-5 align-middle">
-                        <thead>
+                </form>
+            </div>
+        </div>
+    @else
+        <div class="card shadow-lg">
+            <div class="card-header">
+                <div class="card-title">
+                    <i class="fa-solid fa-ticket fs-1 me-3"></i> Liste des tickets de support
+                </div>
+                <div class="card-toolbar d-flex flex-wrap align-items-center">
+                    <div class="me-2">
+                        <input type="text" class="form-control" wire:model.live.debounce.500ms="search" placeholder="Rechercher...">
+                    </div>
+                    <div class="me-2">
+                        <select class="form-select" wire:model.change="statusFilter">
+                            <option value="">Tous les statuts</option>
+                            <option value="open">Ouvert</option>
+                            <option value="pending">En attente</option>
+                            <option value="closed">Fermé</option>
+                        </select>
+                    </div>
+                    <div class="me-2">
+                        <select class="form-select" wire:model.change="priorityFilter">
+                            <option value="">Toutes les priorités</option>
+                            <option value="low">Basse</option>
+                            <option value="medium">Moyenne</option>
+                            <option value="high">Haute</option>
+                        </select>
+                    </div>
+                    <div class="me-2">
+                        <select class="form-select" wire:model.change="serviceFilter">
+                            <option value="">Tous les services</option>
+                            @foreach(\App\Models\Service::all() as $service)
+                                <option value="{{ $service->id }}">{{ $service->name }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div class="mx-2">
+                        <button class="btn btn-sm btn-icon btn-outline btn-outline-dark" wire:click="refreshFilter" data-bs-toggle="tooltip" data-bs-original-title="Rafraichir le filtrage">
+                            <i class="fa-solid fa-refresh"></i>
+                        </button>
+                    </div>
+                    <div class="mx-2">
+                        <button class="btn btn-sm btn-icon btn-primary" wire:click="showCreateForm">
+                            <i class="fa-solid fa-plus"></i>
+                        </button>
+                    </div>
+                </div>
+            </div>
+            <div class="card-body">
+                @if($tickets->count() > 0)
+                    <div class="table-responsive" wire:loading.class="opacity-50 bg-grey-700 table-loading">
+                        <div class="table-loading-message">
+                            <span class="spinner-border spinner-border-sm align-middle me-2"></span> Chargement...
+                        </div>
+                        <table class="table table-row-bordered table-striped table-row-gray-500 border gap-2 gs-5 gx-5 gy-5 align-middle">
+                            <thead>
                             <tr class="fw-bolder fs-3">
                                 <x-base.table-header :direction="$sortDirection" name="priority" :field="$sortBy"></x-base.table-header>
                                 <x-base.table-header :direction="$sortDirection" name="ticket_category_id" :field="$sortBy"></x-base.table-header>
@@ -57,11 +150,11 @@
                                 <x-base.table-header :direction="$sortDirection" name="updated_at" :field="$sortBy">Mise à jour</x-base.table-header>
                                 <th>Actions</th>
                             </tr>
-                        </thead>
-                        <tbody>
+                            </thead>
+                            <tbody>
                             @foreach($tickets as $ticket)
                                 <tr>
-                                    <td class="border border-right-1 border-gray-500">{!! $ticket->priority_label !!} </td>
+                                    <td class="border border-right-1 border-gray-500">{!! $ticket->priority_label !!} <span class="d-none">{{ $ticket->priority }}</span></td>
                                     <td class="border border-right-1 border-gray-500"><i class="fa-solid {{ $ticket->category->icon }} fs-1" data-bs-toggle="tooltip" data-bs-original-title="{{ $ticket->category->name }}"></i> </td>
                                     <td class="border border-right-1 border-gray-500">{{ $ticket->title }}</td>
                                     <td class="border border-right-1 border-gray-500">{{ $ticket->service->name }}</td>
@@ -75,24 +168,25 @@
                                         </div>
                                     </td>
                                     <td class="border border-right-1 border-gray-500">{!! $ticket->status_label !!}</td>
-                                    <td class="border border-right-1 border-gray-500">12/12/2021 12:45</td>
+                                    <td class="border border-right-1 border-gray-500">{{ $ticket->updated_at->format("d/m/Y H:i") }}</td>
                                     <td class="border border-right-1 border-gray-500">
-                                        <a href="" class="btn btn-sm btn-icon btn-outline btn-outline-primary" data-bs-toggle="tooltip" data-bs-original-title="Voir le ticket">
+                                        <a href="{{ route('admin.support.tickets.show', $ticket->id) }}" class="btn btn-sm btn-icon btn-outline btn-outline-primary" data-bs-toggle="tooltip" data-bs-original-title="Voir le ticket">
                                             <i class="fa-solid fa-eye"></i>
                                         </a>
                                     </td>
                                 </tr>
                             @endforeach
-                        </tbody>
-                    </table>
-                </div>
-            @else
-                <x-base.is-null
-                text="Aucun ticket de support n'a été trouvé." />
-            @endif
+                            </tbody>
+                        </table>
+                    </div>
+                @else
+                    <x-base.is-null
+                        text="Aucun ticket de support n'a été trouvé." />
+                @endif
+            </div>
+            <div class="card-footer">
+                {{ $tickets->links() }}
+            </div>
         </div>
-        <div class="card-footer">
-            {{ $tickets->links() }}
-        </div>
-    </div>
+    @endif
 </div>

--- a/resources/views/livewire/admin/support/ticket/ticket-list.blade.php
+++ b/resources/views/livewire/admin/support/ticket/ticket-list.blade.php
@@ -1,3 +1,98 @@
 <div>
-    {{-- The whole world belongs to you. --}}
+    <div class="card shadow-lg">
+        <div class="card-header">
+            <div class="card-title">
+                <i class="fa-solid fa-ticket fs-1 me-3"></i> Liste des tickets de support
+            </div>
+            <div class="card-toolbar d-flex flex-wrap align-items-center">
+                <div class="me-2">
+                    <input type="text" class="form-control" wire:model.live.debounce.500ms="search" placeholder="Rechercher...">
+                </div>
+                <div class="me-2">
+                    <select class="form-select" wire:model.change="statusFilter">
+                        <option value="">Tous les statuts</option>
+                        <option value="open">Ouvert</option>
+                        <option value="pending">En attente</option>
+                        <option value="closed">Fermé</option>
+                    </select>
+                </div>
+                <div class="me-2">
+                    <select class="form-select" wire:model.change="priorityFilter">
+                        <option value="">Toutes les priorités</option>
+                        <option value="low">Basse</option>
+                        <option value="medium">Moyenne</option>
+                        <option value="high">Haute</option>
+                    </select>
+                </div>
+                <div class="me-2">
+                    <select class="form-select" wire:model.change="serviceFilter">
+                        <option value="">Tous les services</option>
+                        @foreach(\App\Models\Service::all() as $service)
+                            <option value="{{ $service->id }}">{{ $service->name }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="mx-2">
+                    <button class="btn btn-sm btn-icon btn-primary">
+                        <i class="fa-solid fa-plus"></i>
+                    </button>
+                </div>
+            </div>
+        </div>
+        <div class="card-body">
+            @if($tickets->count() > 0)
+                <div class="table-responsive" wire:loading.class="opacity-50 bg-grey-700 table-loading">
+                    <div class="table-loading-message">
+                        <span class="spinner-border spinner-border-sm align-middle me-2"></span> Chargement...
+                    </div>
+                    <table class="table table-row-bordered table-striped table-row-gray-500 border gap-2 gs-5 gx-5 gy-5 align-middle">
+                        <thead>
+                            <tr class="fw-bolder fs-3">
+                                <x-base.table-header :direction="$sortDirection" name="priority" :field="$sortBy"></x-base.table-header>
+                                <x-base.table-header :direction="$sortDirection" name="ticket_category_id" :field="$sortBy"></x-base.table-header>
+                                <th>Sujet</th>
+                                <x-base.table-header :direction="$sortDirection" name="service_id" :field="$sortBy">Service</x-base.table-header>
+                                <th>Utilisateurs</th>
+                                <x-base.table-header :direction="$sortDirection" name="status" :field="$sortBy">Etat</x-base.table-header>
+                                <x-base.table-header :direction="$sortDirection" name="updated_at" :field="$sortBy">Mise à jour</x-base.table-header>
+                                <th>Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach($tickets as $ticket)
+                                <tr>
+                                    <td class="border border-right-1 border-gray-500">{!! $ticket->priority_label !!} </td>
+                                    <td class="border border-right-1 border-gray-500"><i class="fa-solid {{ $ticket->category->icon }} fs-1" data-bs-toggle="tooltip" data-bs-original-title="{{ $ticket->category->name }}"></i> </td>
+                                    <td class="border border-right-1 border-gray-500">{{ $ticket->title }}</td>
+                                    <td class="border border-right-1 border-gray-500">{{ $ticket->service->name }}</td>
+                                    <td class="d-flex flex-row align-items-center border border-right-1 border-gray-500">
+                                        <div class="symbol symbol-50px symbol-circle me-2">
+                                            <img src="{{ $ticket->user->avatar }}" alt="">
+                                        </div>
+                                        <div class="d-flex flex-column">
+                                            <a href="{{ route('admin.config.users.show', $ticket->user->id) }}" class="text-hover-primary fw-bold fs-3">{{ $ticket->user->name }}</a>
+                                            <span class="text-muted fs-8 fw-bold">#{{ $ticket->user->token_tag }}</span>
+                                        </div>
+                                    </td>
+                                    <td class="border border-right-1 border-gray-500">{!! $ticket->status_label !!}</td>
+                                    <td class="border border-right-1 border-gray-500">12/12/2021 12:45</td>
+                                    <td class="border border-right-1 border-gray-500">
+                                        <a href="" class="btn btn-sm btn-icon btn-outline btn-outline-primary" data-bs-toggle="tooltip" data-bs-original-title="Voir le ticket">
+                                            <i class="fa-solid fa-eye"></i>
+                                        </a>
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            @else
+                <x-base.is-null
+                text="Aucun ticket de support n'a été trouvé." />
+            @endif
+        </div>
+        <div class="card-footer">
+            {{ $tickets->links() }}
+        </div>
+    </div>
 </div>

--- a/resources/views/livewire/admin/support/ticket/ticket-show.blade.php
+++ b/resources/views/livewire/admin/support/ticket/ticket-show.blade.php
@@ -1,0 +1,117 @@
+<div>
+    <div class="card shadow-lg mb-10">
+        <div class="card-body">
+            <div class="d-flex flex-row justify-content-between">
+                <span class="fw-bolder fs-2x">{{ $ticket->title }}</span>
+                <div class="me-2 d-flex align-items-center">
+                    <span class="me-2">
+                        {!! $ticket->status_label !!}
+                    </span>
+                    {!! $ticket->priority_label !!}
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-sm-12 col-lg-8">
+            <div class="card shadow-lg">
+                <div class="card-header">
+                    <div class="card-title">
+                        <div class="d-flex flex-column">
+                            <span class="text-dark fw-bold fs-2">{{ $ticket->user->name }}</span>
+                            {!! $ticket->user->status_label !!}
+                        </div>
+                    </div>
+                    <div class="card-toolbar">
+                        <span class="fw-bold me-3">Dernière MAJ:</span>
+                        @if($ticketResponses->count() > 0)
+                            @if($ticketResponses->first()->created_at->diffInDays() > 1)
+                                <span>{{ $ticketResponses->first()->created_at->format("d/m/Y à H:i") }}</span>
+                            @else
+                                <span>{{ $ticketResponses->first()->created_at->longRelativeDiffForHumans() }}</span>
+                            @endif
+                        @else
+                            <span class="text-danger">Aucune Réponse</span>
+                        @endif
+                    </div>
+                </div>
+                <livewire:admin.support.ticket.ticket-chat :ticket="$ticket" />
+                <div class="card-footer pt-4">
+                    <div class="d-flex flex-column">
+                        <div class="d-flex align-items-center">
+                            <textarea class="form-control form-control-flush" rows="1" placeholder="Répondre..." wire:model.defer="message"></textarea>
+                            <button class="btn btn-primary ms-2" wire:click="send">Envoyer</button>
+                        </div>
+                        @error('message') <span class="text-danger">{{ $message }}</span> @enderror
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-sm-12 col-lg-4 h-300px h-lg-auto">
+            <div class="card shadow-lg">
+                <div class="card-header">
+                    <div class="card-title">&nbsp;</div>
+                    <div class="card-toolbar gap-2">
+                        @if($ticket->status == 'open' || $ticket->status == 'pending')
+                            <button wire:click="closeTicket" class="btn btn-sm btn-icon btn-outline btn-outline-danger" data-bs-toggle="tooltip" data-bs-original-title="Clôturer le ticket">
+                                <i class="fa-solid fa-lock"></i>
+                            </button>
+                        @else
+                            <button wire:click="openTicket" class="btn btn-sm btn-icon btn-outline btn-outline-success" data-bs-toggle="tooltip" data-bs-original-title="Rouvrir le ticket">
+                                <i class="fa-solid fa-unlock"></i>
+                            </button>
+                        @endif
+                        @if(!$ticket->is_jira_ticket)
+                            <button wire:click="transfertToJira" class="btn btn-sm btn-icon btn-outline btn-outline-dark" data-bs-toggle="tooltip" data-bs-original-title="Transférer à JIRA">
+                                <i class="fa-brands fa-jira"></i>
+                            </button>
+                        @else
+                            <a href="{{ $ticket->jira_info['self'] }}" class="btn btn-sm btn-icon btn-outline btn-outline-warning" data-bs-toggle="tooltip" data-bs-original-title="Voir le ticket sur jira">
+                                <i class="fa-brands fa-jira"></i>
+                            </a>
+                        @endif
+                    </div>
+                </div>
+                <div class="card-body">
+                    <div class="d-flex flex-row justify-content-between align-items-center">
+                        <span class="fw-bold fs-2">Etat</span>
+                        {!! $ticket->status_label !!}
+                    </div>
+                    <div class="separator border-gray-400 my-2"></div>
+                    <div class="d-flex flex-row justify-content-between align-items-center">
+                        <span class="fw-bold fs-2">Priorité</span>
+                        {!! $ticket->priority_label !!}
+                    </div>
+                    <div class="separator border-gray-400 my-2"></div>
+                    <div class="d-flex flex-row justify-content-between align-items-center">
+                        <span class="fw-bold fs-2">Service</span>
+                        {{ $ticket->service->name }}
+                    </div>
+                    <div class="separator border-gray-400 my-2"></div>
+                    <div class="d-flex flex-row justify-content-between align-items-center">
+                        <span class="fw-bold fs-2">Catégorie</span>
+                        <div class="d-flex align-items-center">
+                            <i class="fa-solid {{ $ticket->category->icon }} fs-1 me-2"></i> {{ $ticket->category->name }}
+                        </div>
+                    </div>
+                    <div class="separator border-gray-400 my-2"></div>
+                    <div class="d-flex flex-row justify-content-between align-items-center">
+                        <span class="fw-bold fs-2">Créer le</span>
+                        <div class="d-flex align-items-center">
+                            <span class="me-1">{{ $ticket->created_at->format("d/m/Y à H:i") }}</span>
+                            <span class="text-muted">({{ $ticket->created_at->shortAbsoluteDiffForHumans() }})</span>
+                        </div>
+                    </div>
+                    <div class="separator border-gray-400 my-2"></div>
+                    <div class="d-flex flex-row justify-content-between align-items-center">
+                        <span class="fw-bold fs-2">Mise à jour le</span>
+                        <div class="d-flex align-items-center">
+                            <span class="me-1">{{ $ticket->updated_at->format("d/m/Y à H:i") }}</span>
+                            <span class="text-muted">({{ $ticket->updated_at->shortAbsoluteDiffForHumans() }})</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -100,6 +100,7 @@ Route::prefix('admin')->middleware(['web', 'admin'])->group(function () {
 
         Route::prefix("tickets")->group(function () {
             Route::get('/', \App\Livewire\Admin\Support\Ticket\TicketList::class)->name('admin.support.tickets');
+            Route::get('{id}', \App\Livewire\Admin\Support\Ticket\TicketShow::class)->name('admin.support.tickets.show');
         });
 
         Route::prefix("bugs")->group(function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,7 +22,8 @@ Route::get('/', function () {
 })->name('home');
 
 Route::get('/test', function() {
-    dd(auth()->user()->social);
+    $request = \Jira\Laravel\Facades\Jira::issues()->get('SAVS-2');
+    dd($request);
 });
 
 Route::get('/login', \App\Livewire\Auth\Login::class)->name('login');

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use Jira\Laravel\Facades\Jira;
 
 /*
 |--------------------------------------------------------------------------
@@ -22,7 +23,9 @@ Route::get('/', function () {
 })->name('home');
 
 Route::get('/test', function() {
-    $request = \Jira\Laravel\Facades\Jira::issues()->get('SAVS-2');
+    $request = Jira::issues()->search([
+        "jql" => "project = 'Vortech Studio Helpdesk' ORDER BY created DESC",
+    ])['issues'];
     dd($request);
 });
 


### PR DESCRIPTION
Cette PR ajoute une fonctionnalité de gestion des tickets de support. Elle comprend des modifications sur plusieurs fichiers pour ajouter de nouvelles vues, modèles, observateurs et migrations. Elle ajoute également une dépendance à 'devmoath/jira-laravel' pour la gestion des tickets via Jira. Les utilisateurs peuvent maintenant créer, voir et répondre aux tickets de support, et les tickets peuvent être transférés à Jira.