### PR TITLE
fix(package.json): Mise à jour de la version de Vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "devDependencies": {
         "axios": "^1.6.1",
         "laravel-vite-plugin": "^0.8.0",
-        "vite": "^4.5.0"
+        "vite": ">=4.5.2"
     },
     "dependencies": {
         "@popperjs/core": "^2.11.8",


### PR DESCRIPTION
La version de Vite a été mise à jour de "^4.5.0" à ">=4.5.2" pour assurer la compatibilité avec les dépendances.