### PR TITLE
fix(Branche): Correction de l'authentification Github

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -33,7 +33,7 @@ class Handler extends ExceptionHandler
         $client = new \GuzzleHttp\Client();
         $response = $client->post('https://api.github.com/repos/'.config('updater.github_username').'/'.config('updater.github_repository').'/issues', [
             'headers' => [
-                'Authorization' => 'Bearer ' . config('updater.github_token'),
+                'Authorization' => 'Bearer ' . config('services.github.token'),
                 'Accept' => 'application/vnd.github+json',
                 'X-GitHub-Api-Version' => '2022-11-28'
             ],

--- a/config/services.php
+++ b/config/services.php
@@ -38,6 +38,10 @@ return [
 
     "sendgrid" => [
         "api_key" => env('SENDGRID_API_KEY', null)
+    ],
+
+    'github' => [
+        "token" => env('GH_TOKEN', null),
     ]
 
 ];


### PR DESCRIPTION
Correction de l'authentification Github dans les fichiers Handler.php et services.php pour utiliser la clé de configuration 'services.github.token' au lieu de 'updater.github_token'.